### PR TITLE
api: include inbox keys in get user endpoint

### DIFF
--- a/Notesnook.API/Services/UserService.cs
+++ b/Notesnook.API/Services/UserService.cs
@@ -129,6 +129,7 @@ namespace Notesnook.API.Services
                 PhoneNumber = user.PhoneNumber,
                 AttachmentsKey = userSettings.AttachmentsKey,
                 MonographPasswordsKey = userSettings.MonographPasswordsKey,
+                InboxKeys = userSettings.InboxKeys,
                 Salt = userSettings.Salt,
                 Subscription = subscription,
                 Success = true,


### PR DESCRIPTION
I didn't even realize the api wasn't sending inbox keys at all, my bad