### PR TITLE
docker: fix compose self-hosting and add external Mongo/MinIO/Garage examples

### DIFF
--- a/.env
+++ b/.env
@@ -12,21 +12,26 @@ NOTESNOOK_API_SECRET=
 # Possible values: true/false
 DISABLE_SIGNUPS=false
 
-### SMTP Configuration ###
-# SMTP Configuration is required for sending emails for password reset, 2FA emails etc. You can get SMTP settings from your email provider.
+### SMTP Configuration (optional) ###
+# ================================================================================
+# WARNING: If SMTP is not configured, email 2FA and password-reset emails will
+# NOT work. Newly created users MUST change 2FA to an Authenticator app:
+#   Settings > Auth > Change 2FA method
+# ================================================================================
+# SMTP is used for sending emails for password reset, 2FA emails etc. You can get SMTP settings from your email provider.
 
 # Description: Username for the SMTP connection (most time it is the email address of your account). Check your email provider's documentation to get the appropriate value.
-# Required: yes
+# Required: no
 SMTP_USERNAME=
 # Description: Password for the SMTP connection. Check your email provider's documentation to get the appropriate value.
-# Required: yes
+# Required: no
 SMTP_PASSWORD=
 # Description: Host on which the the SMTP connection is running. Check your email provider's documentation to get the appropriate value.
-# Required: yes
+# Required: no
 # Example: smtp.gmail.com
 SMTP_HOST=
 # Description: Port on which the the SMTP connection is running. Check your email provider's documentation to get the appropriate value.
-# Required: yes
+# Required: no
 # Example: 465
 SMTP_PORT=
 
@@ -42,6 +47,7 @@ TWILIO_AUTH_TOKEN=
 TWILIO_SERVICE_SID=
 
 # Description: Add the origins for which you want to allow CORS. Leave it empty to allow all origins to access your server. If you want to allow multiple origins, seperate each origin with a comma.
+# Note: this value is passed to the server as NOTESNOOK_CORS internally.
 # Required: no
 # Example: https://app.notesnook.com,http://localhost:3000
 NOTESNOOK_CORS_ORIGINS=
@@ -68,6 +74,10 @@ AUTH_SERVER_PUBLIC_URL=http://localhost:8264
 # Required: yes
 # Example: https://attachments.notesnook.com
 ATTACHMENTS_SERVER_PUBLIC_URL=http://localhost:9000
+# Description: This is the public URL for the Notesnook sync API (browser-reachable; used by Monograph).
+# Required: yes
+# Example: http://localhost:5264  or  https://api.yourdomain.com
+NOTESNOOK_API_PUBLIC_URL=http://localhost:5264
 
 # Description: Custom username for the root Minio account. Minio is used for storing your attachments. This must be greater than 3 characters in length.
 # Required: no
@@ -75,3 +85,15 @@ MINIO_ROOT_USER=
 # Description: Custom password for the root Minio account. Minio is used for storing your attachments. This must be greater than 8 characters in length.
 # Required: no
 MINIO_ROOT_PASSWORD=
+
+# Optional: only needed when using `docker compose --profile extras up`
+# Description: Public URL for the CORS proxy service
+CORS_PROXY_PUBLIC_URL=http://localhost:3001
+# Description: Allowed origins for the CORS proxy (* for all origins)
+CORS_PROXY_ALLOWED_ORIGINS=*
+# Description: Public URL for the Inbox API service
+INBOX_API_PUBLIC_URL=http://localhost:5181
+# Description: Public URL for the Themes server
+THEMES_SERVER_PUBLIC_URL=http://localhost:9200
+# Description: Git repository URL for the Themes server
+THEMES_REPO_URL=https://github.com/streetwriters/notesnook-themes.git

--- a/.env
+++ b/.env
@@ -64,19 +64,19 @@ KNOWN_PROXIES=
 NOTESNOOK_APP_PUBLIC_URL=https://app.notesnook.com
 # Description: This is the public URL for the monograph frontend.
 # Required: yes
-# Example: https://monogr.ph
+# Example: https://monogr.yourdomain.com
 MONOGRAPH_PUBLIC_URL=http://localhost:6264
 # Description: This is the public URL for the Authentication server. Used for generating email confirmation & password reset URLs.
 # Required: yes
-# Example: https://auth.streetwriters.co
+# Example: https://auth.yourdomain.com
 AUTH_SERVER_PUBLIC_URL=http://localhost:8264
 # Description: This is the public URL for the S3 attachments server (minio). It'll be used by the Notesnook clients for uploading/downloading attachments.
 # Required: yes
-# Example: https://attachments.notesnook.com
+# Example: https://attachments.yourdomain.com
 ATTACHMENTS_SERVER_PUBLIC_URL=http://localhost:9000
 # Description: This is the public URL for the Notesnook sync API (browser-reachable; used by Monograph).
 # Required: yes
-# Example: http://localhost:5264  or  https://api.yourdomain.com
+# Example: https://api.yourdomain.com
 NOTESNOOK_API_PUBLIC_URL=http://localhost:5264
 
 # Description: Custom username for the root Minio account. Minio is used for storing your attachments. This must be greater than 3 characters in length.

--- a/README.md
+++ b/README.md
@@ -55,17 +55,26 @@ dotnet run --project Streetwriters.Identity/Streetwriters.Identity.csproj
 
 The sync server can easily be started using Docker.
 
+Download `docker-compose.yml` and [`.env`](.env):
+
 ```bash
 wget https://raw.githubusercontent.com/streetwriters/notesnook-sync-server/master/docker-compose.yml
+wget https://raw.githubusercontent.com/streetwriters/notesnook-sync-server/master/.env
 ```
 
-And then use Docker Compose to start the servers:
+Edit `.env` and set at least `NOTESNOOK_API_SECRET`. See `.env` for all configuration options.
+
+Then start the stack:
 
 ```bash
 docker compose up
 ```
 
-This takes care of setting up everything including MongoDB, Minio etc.
+This sets up MongoDB, MinIO, and the Notesnook services.
+
+Optional services (`themes-server`, `cors-proxy`, `inbox-api`): `docker compose --profile extras up`
+
+For external MongoDB, MinIO, or Garage deployments, see [`examples/`](examples/).
 
 ## TODO Self-hosting
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -230,7 +230,8 @@ services:
     networks:
       - notesnook
     depends_on:
-      - setup-themes
+      setup-themes:
+        condition: service_completed_successfully
     healthcheck:
       test: >
         bun -e "fetch('http://127.0.0.1:9000/health')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,14 +25,11 @@ services:
           "INSTANCE_NAME"
           "NOTESNOOK_API_SECRET"
           "DISABLE_SIGNUPS"
-          "SMTP_USERNAME"
-          "SMTP_PASSWORD"
-          "SMTP_HOST"
-          "SMTP_PORT"
           "AUTH_SERVER_PUBLIC_URL"
           "NOTESNOOK_APP_PUBLIC_URL"
           "MONOGRAPH_PUBLIC_URL"
           "ATTACHMENTS_SERVER_PUBLIC_URL"
+          "NOTESNOOK_API_PUBLIC_URL"
         )
 
         # Check each required environment variable
@@ -42,6 +39,23 @@ services:
             exit 1
           fi
         done
+
+        if [ -z "$$SMTP_HOST" ] || [ -z "$$SMTP_PORT" ] || [ -z "$$SMTP_USERNAME" ] || [ -z "$$SMTP_PASSWORD" ]; then
+          cat <<'EOF'
+
+        ================================================================================
+         WARNING: SMTP IS NOT CONFIGURED
+        ================================================================================
+         Email-based 2FA codes and password-reset emails will NOT be sent.
+
+         Newly created users MUST switch 2FA to an Authenticator app:
+           Settings > Auth > Change 2FA method
+
+         Configure SMTP_* in .env if you need email-based 2FA or password reset.
+        ================================================================================
+
+        EOF
+        fi
 
         echo "All required environment variables are set."
     # Ensure the validate service runs first
@@ -153,6 +167,7 @@ services:
       S3_SERVICE_URL: "${ATTACHMENTS_SERVER_PUBLIC_URL}"
       S3_REGION: "us-east-1"
       S3_BUCKET_NAME: "attachments"
+      NOTESNOOK_CORS: ${NOTESNOOK_CORS_ORIGINS:-}
 
   sse-server:
     image: streetwriters/sse:latest
@@ -183,15 +198,102 @@ services:
     networks:
       - notesnook
     healthcheck:
-      test: wget --tries=1 -nv -q  http://localhost:3000/api/health -O- || exit 1
+      test: >
+        bun -e "fetch('http://127.0.0.1:3000/api/health')
+        .then(r => { if (!r.ok) process.exit(1); })
+        .catch(() => process.exit(1))"
       interval: 40s
       timeout: 30s
       retries: 3
       start_period: 60s
     environment:
       <<: *server-discovery
-      API_HOST: http://notesnook-server:5264
+      NODE_ENV: production
+      HOST: 0.0.0.0
+      API_HOST: ${NOTESNOOK_API_PUBLIC_URL:-http://localhost:5264}
       PUBLIC_URL: ${MONOGRAPH_PUBLIC_URL}
+
+  setup-themes:
+    profiles: [extras]
+    image: busybox:latest
+    networks:
+      - notesnook
+    volumes:
+      - themesdata:/data
+    command: ['sh', '-c', 'if [ ! -f /data/installs.json ]; then echo "{}" > /data/installs.json; fi']
+
+  themes-server:
+    profiles: [extras]
+    image: streetwriters/themes-server:latest
+    ports:
+      - 9200:9000
+    networks:
+      - notesnook
+    depends_on:
+      - setup-themes
+    healthcheck:
+      test: >
+        bun -e "fetch('http://127.0.0.1:9000/health')
+        .then(r => { if (!r.ok) process.exit(1); })
+        .catch(() => process.exit(1))"
+      interval: 40s
+      timeout: 30s
+      retries: 3
+      start_period: 60s
+    environment:
+      HOST: 0.0.0.0
+      PORT: 9000
+      THEMES_REPO_URL: ${THEMES_REPO_URL:-https://github.com/streetwriters/notesnook-themes.git}
+    volumes:
+      - type: volume
+        source: themesdata
+        target: /installs.json
+        volume:
+          subpath: installs.json
+
+  cors-proxy:
+    profiles: [extras]
+    image: streetwriters/cors-proxy:latest
+    ports:
+      - 3001:3000
+    networks:
+      - notesnook
+    healthcheck:
+      test: >
+        bun -e "fetch('http://127.0.0.1:3000/health')
+        .then(r => { if (!r.ok) process.exit(1); })
+        .catch(() => process.exit(1))"
+      interval: 40s
+      timeout: 30s
+      retries: 3
+      start_period: 60s
+    environment:
+      HOST: 0.0.0.0
+      PORT: 3000
+      ALLOWED_ORIGINS: ${CORS_PROXY_ALLOWED_ORIGINS:-*}
+
+  inbox-api:
+    profiles: [extras]
+    image: streetwriters/notesnook-inbox:latest
+    ports:
+      - 5181:5181
+    networks:
+      - notesnook
+    depends_on:
+      - notesnook-server
+    healthcheck:
+      test: >
+        bun -e "fetch('http://127.0.0.1:5181/health')
+        .then(r => { if (!r.ok) process.exit(1); })
+        .catch(() => process.exit(1))"
+      interval: 40s
+      timeout: 30s
+      retries: 3
+      start_period: 60s
+    environment:
+      HOST: 0.0.0.0
+      PORT: 5181
+      NOTESNOOK_API_SERVER_URL: http://notesnook-server:5264
 
   autoheal:
     image: willfarrell/autoheal:latest
@@ -212,4 +314,4 @@ networks:
 volumes:
   dbdata:
   s3data:
-
+  themesdata:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,50 @@
+# Docker Compose Examples
+
+Reference deployments that split infrastructure from the Notesnook stack. Each example overrides the root [`docker-compose.yml`](../docker-compose.yml) instead of duplicating it.
+
+## Pattern
+
+Run all commands from the **repository root**.
+
+| Step | Compose files | Role |
+|------|---------------|------|
+| 1. Infra | `examples/<example>/infra.compose.yml` | MongoDB, MinIO, or Garage on `notesnook-shared` |
+| 2. Notesnook | `docker-compose.yml` + `examples/<example>/notesnook.override.yml` | Disables embedded services; patches connection strings |
+
+```bash
+# 1. Merge example vars into root .env (see examples/<example>/.env.example)
+# 2. Start infrastructure
+docker compose -f examples/<example>/infra.compose.yml up -d
+
+# 3. Start Notesnook (one-time setup for garage — see example README)
+docker compose -f docker-compose.yml -f examples/<example>/notesnook.override.yml up -d
+
+# Optional extras
+docker compose -f docker-compose.yml -f examples/<example>/notesnook.override.yml --profile extras up -d
+
+# Tear down (reverse order)
+docker compose -f docker-compose.yml -f examples/<example>/notesnook.override.yml down
+docker compose -f examples/<example>/infra.compose.yml down
+```
+
+## Environment
+
+The root [`.env`](../.env) is loaded automatically when running from the repository root. Each example ships a **delta-only** [`.env.example`](external-mongodb/.env.example) listing only variables that differ — merge those lines into your root `.env`.
+
+Infra-only variables (e.g. `GARAGE_RPC_SECRET`) are in `infra.env.example` where applicable; pass with `--env-file` or merge into root `.env`.
+
+## Examples
+
+| Example | External dependency | Notes |
+|---------|---------------------|-------|
+| [external-mongodb](external-mongodb/) | MongoDB | Embedded MinIO stays enabled |
+| [external-minio](external-minio/) | MinIO | Embedded MongoDB stays enabled |
+| [garage](garage/) | [GarageHQ](https://garagehq.deuxfleurs.fr/) S3 | Manual bucket setup via `setup-garage.sh` |
+
+## Shared network
+
+Infra compose files create **`notesnook-shared`**. Override files attach Notesnook services to it as an external network. Run only one infra example at a time on the same host.
+
+## Root compose
+
+The all-in-one stack: [`docker-compose.yml`](../docker-compose.yml) (no override file).

--- a/examples/external-minio/.env.example
+++ b/examples/external-minio/.env.example
@@ -1,0 +1,6 @@
+# Merge these into the repository root .env (see /.env for all other variables).
+#
+# MINIO_ROOT_USER and MINIO_ROOT_PASSWORD must match examples/external-minio/infra.env.example
+# when starting the external MinIO infra stack.
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin

--- a/examples/external-minio/README.md
+++ b/examples/external-minio/README.md
@@ -1,0 +1,43 @@
+# External MinIO
+
+MinIO runs in a separate compose project. The Notesnook stack uses the root [`docker-compose.yml`](../../docker-compose.yml) with [`notesnook.override.yml`](notesnook.override.yml), which disables embedded `notesnook-s3` / `setup-s3` and points at external MinIO. Embedded MongoDB is unchanged.
+
+## Setup
+
+From the **repository root**:
+
+```bash
+# Ensure MINIO_* in root .env match infra.env.example
+# Merge notesnook delta if needed (see .env.example)
+
+# 1. MinIO + bucket setup
+docker compose -f examples/external-minio/infra.compose.yml \
+  --env-file examples/external-minio/infra.env.example up -d
+
+# Wait for notesnook-minio-setup to complete
+docker compose -f examples/external-minio/infra.compose.yml ps -a
+
+# 2. Notesnook
+docker compose -f docker-compose.yml -f examples/external-minio/notesnook.override.yml up -d
+```
+
+## Environment
+
+| File | Purpose |
+|------|---------|
+| [`infra.env.example`](infra.env.example) | `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` for infra stack |
+| [`.env.example`](.env.example) | Notesnook delta (credentials must match infra) |
+
+Merge `MINIO_*` into root [`.env`](../../.env) so the sync server uses the same credentials.
+
+## Stop
+
+```bash
+docker compose -f docker-compose.yml -f examples/external-minio/notesnook.override.yml down
+docker compose -f examples/external-minio/infra.compose.yml down
+```
+
+## Notes
+
+- Bucket `attachments` is created by `notesnook-minio-setup` on first infra start.
+- `S3_INTERNAL_SERVICE_URL` is overridden to `http://notesnook-minio:9000`.

--- a/examples/external-minio/infra.compose.yml
+++ b/examples/external-minio/infra.compose.yml
@@ -1,0 +1,47 @@
+name: notesnook-external-minio-infra
+
+services:
+  notesnook-minio:
+    image: minio/minio:RELEASE.2024-07-29T22-14-52Z
+    hostname: notesnook-minio
+    ports:
+      - 9000:9000
+    networks:
+      - notesnook-shared
+    volumes:
+      - s3data:/data/s3
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_BROWSER: "on"
+    command: server /data/s3 --console-address :9090
+    healthcheck:
+      test: timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1
+      interval: 40s
+      timeout: 30s
+      retries: 3
+      start_period: 60s
+
+  notesnook-minio-setup:
+    image: minio/mc:RELEASE.2024-07-26T13-08-44Z
+    depends_on:
+      notesnook-minio:
+        condition: service_healthy
+    networks:
+      - notesnook-shared
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    command:
+      - /bin/bash
+      - -c
+      - |
+        mc alias set minio http://notesnook-minio:9000 ${MINIO_ROOT_USER:-minioadmin} ${MINIO_ROOT_PASSWORD:-minioadmin}
+        mc mb minio/attachments -p
+
+networks:
+  notesnook-shared:
+    name: notesnook-shared
+
+volumes:
+  s3data:

--- a/examples/external-minio/infra.env.example
+++ b/examples/external-minio/infra.env.example
@@ -1,0 +1,2 @@
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin

--- a/examples/external-minio/notesnook.override.yml
+++ b/examples/external-minio/notesnook.override.yml
@@ -1,0 +1,20 @@
+services:
+  notesnook-s3:
+    profiles: [embedded-disabled]
+
+  setup-s3:
+    profiles: [embedded-disabled]
+
+  notesnook-server:
+    networks:
+      - notesnook
+      - notesnook-shared
+    depends_on: !override
+      identity-server:
+        condition: service_started
+    environment:
+      S3_INTERNAL_SERVICE_URL: "http://notesnook-minio:9000"
+
+networks:
+  notesnook-shared:
+    external: true

--- a/examples/external-mongodb/.env.example
+++ b/examples/external-mongodb/.env.example
@@ -1,0 +1,4 @@
+# Merge these into the repository root .env (see /.env for all other variables).
+
+MONGODB_CONNECTION_STRING_IDENTITY=mongodb://notesnook-mongodb:27017/identity?replSet=rs0
+MONGODB_CONNECTION_STRING=mongodb://notesnook-mongodb:27017/?replSet=rs0

--- a/examples/external-mongodb/README.md
+++ b/examples/external-mongodb/README.md
@@ -1,0 +1,36 @@
+# External MongoDB
+
+MongoDB runs in a separate compose project. The Notesnook stack uses the root [`docker-compose.yml`](../../docker-compose.yml) with [`notesnook.override.yml`](notesnook.override.yml), which disables the embedded `notesnook-db` service and points at external Mongo. Embedded MinIO is unchanged.
+
+## Setup
+
+From the **repository root**:
+
+```bash
+# Merge into root .env
+cat examples/external-mongodb/.env.example >> .env
+# set NOTESNOOK_API_SECRET and other required root .env values
+
+# 1. MongoDB
+docker compose -f examples/external-mongodb/infra.compose.yml up -d
+
+# 2. Notesnook
+docker compose -f docker-compose.yml -f examples/external-mongodb/notesnook.override.yml up -d
+```
+
+## Environment (delta)
+
+See [`.env.example`](.env.example) — only `MONGODB_CONNECTION_STRING*` overrides are needed beyond the root `.env`.
+
+## Stop
+
+```bash
+docker compose -f docker-compose.yml -f examples/external-mongodb/notesnook.override.yml down
+docker compose -f examples/external-mongodb/infra.compose.yml down
+```
+
+## Notes
+
+- Replica set `rs0` is required; the infra healthcheck initializes it.
+- Host port `27017` is exposed for debugging.
+- If infra stops, `identity-server` and `notesnook-server` fail until MongoDB is back.

--- a/examples/external-mongodb/infra.compose.yml
+++ b/examples/external-mongodb/infra.compose.yml
@@ -1,0 +1,26 @@
+name: notesnook-external-mongodb-infra
+
+services:
+  notesnook-mongodb:
+    image: mongo:7.0.12
+    hostname: notesnook-mongodb
+    ports:
+      - 27017:27017
+    volumes:
+      - dbdata:/data/db
+    networks:
+      - notesnook-shared
+    command: --replSet rs0 --bind_ip_all
+    healthcheck:
+      test: echo 'try { rs.status() } catch (err) { rs.initiate() }; db.runCommand("ping").ok' | mongosh mongodb://localhost:27017 --quiet
+      interval: 40s
+      timeout: 30s
+      retries: 3
+      start_period: 60s
+
+networks:
+  notesnook-shared:
+    name: notesnook-shared
+
+volumes:
+  dbdata:

--- a/examples/external-mongodb/notesnook.override.yml
+++ b/examples/external-mongodb/notesnook.override.yml
@@ -1,0 +1,31 @@
+services:
+  notesnook-db:
+    profiles: [embedded-disabled]
+
+  identity-server:
+    depends_on: !override
+      validate:
+        condition: service_completed_successfully
+    networks:
+      - notesnook
+      - notesnook-shared
+    environment:
+      MONGODB_CONNECTION_STRING: ${MONGODB_CONNECTION_STRING_IDENTITY}
+
+  notesnook-server:
+    networks:
+      - notesnook
+      - notesnook-shared
+    depends_on: !override
+      notesnook-s3:
+        condition: service_started
+      setup-s3:
+        condition: service_started
+      identity-server:
+        condition: service_started
+    environment:
+      MONGODB_CONNECTION_STRING: ${MONGODB_CONNECTION_STRING}
+
+networks:
+  notesnook-shared:
+    external: true

--- a/examples/garage/.env.example
+++ b/examples/garage/.env.example
@@ -1,0 +1,6 @@
+# Merge these into the repository root .env (see /.env for all other variables).
+# Fill after running examples/garage/setup-garage.sh
+
+GARAGE_ACCESS_KEY_ID=
+GARAGE_ACCESS_KEY_SECRET=
+ATTACHMENTS_SERVER_PUBLIC_URL=http://localhost:3900

--- a/examples/garage/README.md
+++ b/examples/garage/README.md
@@ -1,0 +1,57 @@
+# GarageHQ S3
+
+[Garage](https://garagehq.deuxfleurs.fr/) replaces embedded MinIO. The Notesnook stack uses the root [`docker-compose.yml`](../../docker-compose.yml) with [`notesnook.override.yml`](notesnook.override.yml). MongoDB stays embedded.
+
+Based on [PR #79](https://github.com/streetwriters/notesnook-sync-server/pull/79), with community review adjustments:
+
+- Notesnook uses **presigned URLs** — no public bucket policy required.
+- Do **not** use `aws s3api put-bucket-policy` for public read ([Garage S3 compatibility](https://garagehq.deuxfleurs.fr/documentation/reference-manual/s3-compatibility/)).
+- Use port **3900** (S3 API) for `ATTACHMENTS_SERVER_PUBLIC_URL` when not behind a reverse proxy.
+
+## Setup
+
+From the **repository root**:
+
+```bash
+# 1. Generate RPC secret and add to root .env or use --env-file
+openssl rand -hex 32
+# add GARAGE_RPC_SECRET=... to .env (see infra.env.example)
+
+# 2. Garage infra
+docker compose -f examples/garage/infra.compose.yml up -d
+
+# 3. One-time bucket/key setup (from repo root)
+./examples/garage/setup-garage.sh
+
+# 4. Merge keys into root .env (see .env.example)
+# 5. Notesnook
+docker compose -f docker-compose.yml -f examples/garage/notesnook.override.yml up -d
+```
+
+`notesnook-server` may stay unhealthy until valid `GARAGE_ACCESS_KEY_*` values are in root `.env`:
+
+```bash
+docker compose -f docker-compose.yml -f examples/garage/notesnook.override.yml up -d --force-recreate notesnook-server
+```
+
+## Environment
+
+| File | Purpose |
+|------|---------|
+| [`infra.env.example`](infra.env.example) | `GARAGE_RPC_SECRET` for infra |
+| [`.env.example`](.env.example) | `GARAGE_ACCESS_KEY_*` and `ATTACHMENTS_SERVER_PUBLIC_URL` (merge into root `.env`) |
+
+## Stop
+
+```bash
+docker compose -f docker-compose.yml -f examples/garage/notesnook.override.yml down
+docker compose -f examples/garage/infra.compose.yml down
+```
+
+## Manual setup
+
+If `setup-garage.sh` fails, follow PR #79 layout/bucket/key steps manually. Skip public bucket policy. Optional bucket alias only for Garage web port 3902.
+
+## MongoDB
+
+This example only externalizes S3. For external MongoDB, combine with [external-mongodb](../external-mongodb/) or use the root all-in-one compose.

--- a/examples/garage/garage.toml
+++ b/examples/garage/garage.toml
@@ -1,0 +1,21 @@
+metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+db_engine = "lmdb"
+
+replication_factor = 1
+consistency_mode = "consistent"
+
+rpc_bind_addr = "[::]:3901"
+rpc_public_addr = "127.0.0.1:3901"
+
+[s3_api]
+s3_region = "us-east-1"
+api_bind_addr = "[::]:3900"
+root_domain = ".s3.garage"
+
+[s3_web]
+bind_addr = "[::]:3902"
+root_domain = ".web.garage"
+
+[admin]
+api_bind_addr = "[::]:3903"

--- a/examples/garage/infra.compose.yml
+++ b/examples/garage/infra.compose.yml
@@ -1,0 +1,31 @@
+name: notesnook-garage-infra
+
+services:
+  notesnook-garage:
+    image: dxflrs/garage:v2.3.0
+    hostname: notesnook-garage
+    restart: unless-stopped
+    ports:
+      - 3900:3900
+      - 3901:3901
+      - 3902:3902
+    networks:
+      - notesnook-shared
+    volumes:
+      - s3data:/var/lib/garage
+      - ./garage.toml:/etc/garage.toml:ro
+    environment:
+      GARAGE_RPC_SECRET: ${GARAGE_RPC_SECRET}
+    healthcheck:
+      test: ["CMD", "/garage", "status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+networks:
+  notesnook-shared:
+    name: notesnook-shared
+
+volumes:
+  s3data:

--- a/examples/garage/infra.env.example
+++ b/examples/garage/infra.env.example
@@ -1,0 +1,2 @@
+# Generate with: openssl rand -hex 32
+GARAGE_RPC_SECRET=

--- a/examples/garage/notesnook.override.yml
+++ b/examples/garage/notesnook.override.yml
@@ -1,0 +1,22 @@
+services:
+  notesnook-s3:
+    profiles: [embedded-disabled]
+
+  setup-s3:
+    profiles: [embedded-disabled]
+
+  notesnook-server:
+    networks:
+      - notesnook
+      - notesnook-shared
+    depends_on: !override
+      identity-server:
+        condition: service_started
+    environment:
+      S3_INTERNAL_SERVICE_URL: "http://notesnook-garage:3900"
+      S3_ACCESS_KEY_ID: "${GARAGE_ACCESS_KEY_ID}"
+      S3_ACCESS_KEY: "${GARAGE_ACCESS_KEY_SECRET}"
+
+networks:
+  notesnook-shared:
+    external: true

--- a/examples/garage/setup-garage.sh
+++ b/examples/garage/setup-garage.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+BUCKET="${GARAGE_BUCKET:-attachments}"
+ZONE="${GARAGE_ZONE:-us-east-1}"
+CAPACITY="${GARAGE_CAPACITY:-10G}"
+KEY_NAME="${GARAGE_KEY_NAME:-notesnook-key}"
+ENDPOINT="${GARAGE_S3_ENDPOINT:-http://127.0.0.1:3900}"
+
+echo -e "${GREEN}--- Notesnook Garage setup ---${NC}"
+
+CONTAINER_NAME="${GARAGE_CONTAINER_NAME:-}"
+if [ -z "$CONTAINER_NAME" ]; then
+  CONTAINER_NAME=$(docker ps --format '{{.Names}}' | grep -E 'notesnook-garage|garage' | head -n 1 || true)
+fi
+
+if [ -z "$CONTAINER_NAME" ]; then
+  echo -e "${RED}Error: no running Garage container found.${NC}"
+  echo "Start infra first (from repo root): docker compose -f examples/garage/infra.compose.yml up -d"
+  exit 1
+fi
+
+echo -e "Using container: ${GREEN}${CONTAINER_NAME}${NC}"
+
+echo -e "\n${YELLOW}[1/5] Layout${NC}"
+NODE_ID=""
+for _ in $(seq 1 10); do
+  NODE_ID=$(docker exec "$CONTAINER_NAME" /garage node id -q | cut -d '@' -f 1 || true)
+  [ -n "$NODE_ID" ] && break
+  sleep 2
+done
+
+if [ -z "$NODE_ID" ]; then
+  echo -e "${RED}Error: could not read Garage node id.${NC}"
+  exit 1
+fi
+
+echo "Node ID: $NODE_ID"
+docker exec "$CONTAINER_NAME" /garage layout assign -z "$ZONE" -c "$CAPACITY" "$NODE_ID"
+echo "yes" | docker exec -i "$CONTAINER_NAME" /garage layout apply --version 1
+
+echo -e "\n${YELLOW}[2/5] Bucket${NC}"
+docker exec "$CONTAINER_NAME" /garage bucket create "$BUCKET" || true
+
+if [ -n "${GARAGE_BUCKET_ALIAS:-}" ]; then
+  echo "Aliasing bucket to ${GARAGE_BUCKET_ALIAS} (optional website access)"
+  docker exec "$CONTAINER_NAME" /garage bucket alias "$BUCKET" "$GARAGE_BUCKET_ALIAS"
+fi
+
+echo -e "\n${YELLOW}[3/5] API key${NC}"
+KEY_INFO=$(docker exec "$CONTAINER_NAME" /garage key create "$KEY_NAME")
+echo "$KEY_INFO"
+
+KEY_ID=$(echo "$KEY_INFO" | awk '/Key ID:/ {print $3}')
+SECRET_KEY=$(echo "$KEY_INFO" | awk '/Secret key:/ {print $3}')
+
+if [ -z "$KEY_ID" ] || [ -z "$SECRET_KEY" ]; then
+  echo -e "${RED}Error: failed to parse key id/secret from garage output.${NC}"
+  exit 1
+fi
+
+echo -e "\n${YELLOW}[4/5] Bucket permissions${NC}"
+docker exec "$CONTAINER_NAME" /garage bucket allow "$BUCKET" --read --write --owner --key "$KEY_ID"
+
+echo -e "\n${YELLOW}[5/5] CORS (aws-cli)${NC}"
+docker run --rm \
+  --env AWS_ACCESS_KEY_ID="$KEY_ID" \
+  --env AWS_SECRET_ACCESS_KEY="$SECRET_KEY" \
+  --add-host=host.docker.internal:host-gateway \
+  amazon/aws-cli \
+  --endpoint-url "$ENDPOINT" \
+  s3api put-bucket-cors --bucket "$BUCKET" --cors-configuration '{
+    "CORSRules": [
+      {
+        "AllowedHeaders": ["*"],
+        "AllowedMethods": ["GET", "PUT", "POST", "DELETE", "HEAD"],
+        "AllowedOrigins": ["*"],
+        "ExposeHeaders": ["ETag"]
+      }
+    ]
+  }'
+
+cat <<EOF
+
+${GREEN}--- Setup complete ---${NC}
+
+Merge these into the repository root .env (see examples/garage/.env.example):
+
+  GARAGE_ACCESS_KEY_ID=$KEY_ID
+  GARAGE_ACCESS_KEY_SECRET=$SECRET_KEY
+  ATTACHMENTS_SERVER_PUBLIC_URL=$ENDPOINT
+
+Notes:
+  - Notesnook uses presigned URLs for attachments; public bucket policies are not required.
+  - Use the S3 API URL (port 3900) for ATTACHMENTS_SERVER_PUBLIC_URL unless you proxy it.
+  - Do not use aws s3api put-bucket-policy for public read; Garage does not support this like MinIO.
+
+Then restart the sync server (from repo root):
+
+  docker compose -f docker-compose.yml -f examples/garage/notesnook.override.yml up -d --force-recreate notesnook-server
+
+EOF


### PR DESCRIPTION
## Summary

Improves the default Docker Compose self-hosting stack and adds reference deployments for external MongoDB, MinIO, and GarageHQ.

### Compose & `.env`

- Make SMTP optional at startup; print a clear warning when unset (email 2FA / password reset unavailable; users should switch to Authenticator 2FA)
- Add `NOTESNOOK_API_PUBLIC_URL` (required) for browser-reachable sync API URL
- Fix Monograph: use public `API_HOST`, set `NODE_ENV=production` / `HOST=0.0.0.0`, replace `wget` healthcheck with Bun `fetch`
- Pass `NOTESNOOK_CORS_ORIGINS` to sync server as `NOTESNOOK_CORS`
- Add optional `extras` profile: `themes-server`, `cors-proxy`, `inbox-api` (+ `setup-themes` volume init)
- Document new env vars in `.env` (extras URLs, CORS note)

### Examples (`examples/`)

Three override-based patterns — run from repo root, no duplicated compose:

| Example | External | Embedded |
|---------|----------|----------|
| `external-mongodb` | MongoDB | MinIO |
| `external-minio` | MinIO | MongoDB |
| `garage` | GarageHQ S3 | MongoDB |

Each provides `infra.compose.yml`, `notesnook.override.yml`, delta `.env.example`, and README. Garage includes `setup-garage.sh` (presigned URLs, no public bucket policy).

### Docs

- Update root README docker section: download `.env` + compose, configure before `up`, link to `examples/`

## Related issues

- #49 — Monograph healthcheck (`wget` missing in image)
- #75 — Monograph `API_HOST` must be public URL
- #78 — Monograph `NODE_ENV` / `HOST` for healthchecks
- #73 — Garage external S3 (PR #79 pattern)
- #24 — CORS env variable use the wrong name


## Test plan

- [x] `docker compose config` — default stack validates
- [x] `docker compose up` with empty SMTP — validate prints warning, stack starts
- [x] `docker compose --profile extras config` — extras services present
- [x] `docker compose --profile extras up` with empty SMTP — validate prints warning, stack starts with extras
- [x] `docker compose config` for each example override from repo root:
  - [x] `examples/external-mongodb/notesnook.override.yml`
  - [x] `examples/external-minio/notesnook.override.yml`
  - [x] `examples/garage/notesnook.override.yml`

## Notes
AI was not used to write the different docker-compose files and configurations files.
AI was used to create the different README and document the different envs vars.